### PR TITLE
Add a plt.pause to allow event handlers to catch up

### DIFF
--- a/sine-prediction/nupic_output.py
+++ b/sine-prediction/nupic_output.py
@@ -145,6 +145,7 @@ class NuPICPlotOutput(NuPICOutput):
       self.anomaly_score_line.set_ydata(self.anomaly_score)  # update the data
     plt.draw()
     plt.tight_layout()
+    plt.pause(1)
 
 
 


### PR DESCRIPTION
Depending on the back-end used in matplotlib, and the way a window is interacted with, the window can freeze and/or crash. Background processing can continue with certain back-ends, but with a frozen  window. See https://github.com/matplotlib/matplotlib/issues/2134/ for this closed issue. Adding a pause allows event handlers to 'catch up' (such as moving and resizing events).
